### PR TITLE
runs-on: ubuntu-latest (Github Actions)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ name: CI
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ name: Release
 jobs:
   deployable:
     name: Stable IJ Plugin
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
> The ubuntu-16.04 environment is deprecated and will be removed on September 20, 2021. Migrate to ubuntu-latest instead. For more details see https://github.com/actions/virtual-environments/issues/3287