### PR TITLE
Show the status of the Hermit plugin in the status bar.

### DIFF
--- a/src/main/kotlin/com/squareup/cash/hermit/ui/statusbar/HermitStatusBarPresentation.kt
+++ b/src/main/kotlin/com/squareup/cash/hermit/ui/statusbar/HermitStatusBarPresentation.kt
@@ -1,0 +1,34 @@
+package com.squareup.cash.hermit.ui.statusbar
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.StatusBarWidget
+import com.intellij.util.Consumer
+import com.squareup.cash.hermit.Hermit
+import com.squareup.cash.hermit.UI
+import java.awt.event.MouseEvent
+
+class HermitStatusBarPresentation(val project: Project) : StatusBarWidget.TextPresentation {
+  override fun getTooltipText(): String? {
+    return "Hermit status"
+  }
+
+  override fun getClickConsumer(): Consumer<MouseEvent>? {
+    return Consumer<MouseEvent> {
+      if ( Hermit(project).hasHermit() && !Hermit(project).isHermitEnabled() ) {
+        UI.askToEnableHermit(project)
+      }
+    }
+  }
+
+  override fun getText(): String {
+    return if ( Hermit(project).isHermitEnabled() ) {
+      "Hermit enabled"
+    } else {
+      "Hermit disabled"
+    }
+  }
+
+  override fun getAlignment(): Float {
+    return 0.0f
+  }
+}

--- a/src/main/kotlin/com/squareup/cash/hermit/ui/statusbar/HermitStatusBarWidget.kt
+++ b/src/main/kotlin/com/squareup/cash/hermit/ui/statusbar/HermitStatusBarWidget.kt
@@ -1,0 +1,19 @@
+package com.squareup.cash.hermit.ui.statusbar
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.StatusBarWidget.WidgetPresentation
+import com.intellij.openapi.wm.impl.status.EditorBasedWidget
+
+class HermitStatusBarWidget(project: Project) : EditorBasedWidget(project) {
+    override fun ID(): String {
+      return ID
+    }
+
+    override fun getPresentation(): WidgetPresentation? {
+      return HermitStatusBarPresentation(project)
+    }
+
+  companion object {
+    const val ID = "HermitStatusBarWidget"
+  }
+}

--- a/src/main/kotlin/com/squareup/cash/hermit/ui/statusbar/HermitStatusBarWidgetFactory.kt
+++ b/src/main/kotlin/com/squareup/cash/hermit/ui/statusbar/HermitStatusBarWidgetFactory.kt
@@ -1,0 +1,36 @@
+package com.squareup.cash.hermit.ui.statusbar
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.StatusBar
+import com.intellij.openapi.wm.StatusBarWidget
+import com.intellij.openapi.wm.StatusBarWidgetFactory
+import com.squareup.cash.hermit.Hermit
+
+class HermitStatusBarWidgetFactory : StatusBarWidgetFactory {
+  override fun getId(): String {
+    return ID
+  }
+
+  override fun getDisplayName(): String {
+    return "Hermit Status"
+  }
+
+  override fun isAvailable(project: Project): Boolean {
+    return Hermit(project).hasHermit()
+  }
+
+  override fun createWidget(project: Project): StatusBarWidget {
+    return HermitStatusBarWidget(project)
+  }
+
+  override fun disposeWidget(project: StatusBarWidget) {
+  }
+
+  override fun canBeEnabledOn(project: StatusBar): Boolean {
+    return true
+  }
+
+  companion object {
+    const val ID = "HermitStatusBarWidgetFactory"
+  }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -39,6 +39,7 @@
 
     <extensions defaultExtensionNs="com.intellij">
         <toolsCustomizer implementation="com.squareup.cash.hermit.execution.HermitToolsCustomiser" />
+        <statusBarWidgetFactory implementation="com.squareup.cash.hermit.ui.statusbar.HermitStatusBarWidgetFactory"/>
     </extensions>
 
     <extensionPoints>


### PR DESCRIPTION
- If the project does not have Hermit installed, show nothing.
- If the project has Hermit, but the plugin is not enabled, show "Hermit disabled"
- If the project has Hermit, and the plugin is enabled, show "Hermit enabled"

Clicking the "Hermit disabled" status re-shows the dialog to enable Hermit for the project.

When enabled:
![Screen Shot 2021-10-19 at 3 24 17 pm](https://user-images.githubusercontent.com/996451/137844827-85992288-bd0f-4b07-8ca0-d35802fea957.png)

When disabled:
![Screen Shot 2021-10-19 at 3 25 31 pm](https://user-images.githubusercontent.com/996451/137844839-094ca894-a850-4997-844d-0da80aa758b8.png)
