### PR TITLE
Give Hermit actions context

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -29,11 +29,11 @@
     <actions>
         <action id="org.squareup.cash.hermit.enable"
                 class="com.squareup.cash.hermit.action.EnableHermitAction"
-                text="Yes" description="Enable Hermit for the Project">
+                text="Enable Hermit" description="Enable Hermit for the Project">
         </action>
         <action id="org.squareup.cash.hermit.dont-enable"
                 class="com.squareup.cash.hermit.action.DontEnableHermitAction"
-                text="No" description="Don't enable Hermit for the Project">
+                text="Don't Enable Hermit" description="Don't enable Hermit for the Project">
         </action>
     </actions>
 


### PR DESCRIPTION
This is what they look like right now in the action menu:
<img width="725" alt="Screen Shot 2021-11-17 at 2 53 27 pm" src="https://user-images.githubusercontent.com/24025/142131600-dcca412d-dd77-4139-922b-9db618ef2269.png">

"Yes" could be "Enable Hermit", "No" could be "Don't Enable Hermit."

(tbh I wish for "Disable Hermit" but hey I won't let that stop this PR)
