### PR TITLE
Show Hermit status as failed if the binary execution failed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,6 @@ jobs:
       - name: Init Hermit
         run: ./bin/hermit env -r >> $GITHUB_ENV
       - name: Test
-        run: gradle test
+        run: gradle test --info
       - name: Plugin verification
         run: gradle runPluginVerifier

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
           ./bin/hermit install -d
       - name: Test
         run: |
-          ./bin/gradle test
+          ./bin/gradle test --info
       - name: Publish
         env:
           JETBRAINS_TOKEN: ${{ secrets.JETBRAINS_PLUGIN_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -92,3 +92,7 @@ dependencies {
 tasks.buildSearchableOptions {
     enabled = false
 }
+
+tasks.test {
+    systemProperty("idea.force.use.core.classloader", "true")
+}

--- a/src/main/kotlin/com/squareup/cash/hermit/ProjectExtensions.kt
+++ b/src/main/kotlin/com/squareup/cash/hermit/ProjectExtensions.kt
@@ -114,7 +114,7 @@ private fun Project.runHermit(vararg args: String): Result<Process> {
         return failure("No Hermit found in the project")
     }
 
-    val cmd = "hermit"
+    val cmd = "./hermit"
     val binDir = this.binDir()?.toNioPath()?.toFile()
     val commandLine = GeneralCommandLine(cmd, *args)
     commandLine.workDirectory = binDir


### PR DESCRIPTION
Adds a new status "Hermit failed" if the `hermit install` execution fails. Clicking the status retries the command.
This should make it easier to debug issues, and means the user does not need to close and re-open the project if they are, for example, offline when hermit tries to download the packages for the first time.

Implements https://github.com/cashapp/hermit-ij-plugin/issues/29

Also, fixes how tests are run in CI