### PR TITLE
Only refresh on hermit file changes

### DIFF
--- a/src/main/kotlin/com/squareup/cash/hermit/Hermit.kt
+++ b/src/main/kotlin/com/squareup/cash/hermit/Hermit.kt
@@ -91,7 +91,7 @@ object Hermit {
         }
 
         private fun runInstall() {
-            log.debug("installing hermit packages")
+            log.info("installing hermit packages")
             val task = BackgroundableWrapper(project, "Installing Hermit Packages", Runnable {
                 when (val result = project.installHermitPackages()) {
                     is Failure -> {

--- a/src/main/kotlin/com/squareup/cash/hermit/Hermit.kt
+++ b/src/main/kotlin/com/squareup/cash/hermit/Hermit.kt
@@ -131,7 +131,7 @@ object Hermit {
             this.isHermitProject = project.hasHermit()
 
             if (this.isHermitProject && this.status == HermitStatus.Enabled) {
-                log.debug(project.name + ": updating hermit status from disk")
+                log.info(project.name + ": updating hermit status from disk")
                 when(val prop =  project.hermitProperties()) {
                     is Failure -> {
                         log.warn(project.name + ": updating hermit status failed: " + prop.a)

--- a/src/main/kotlin/com/squareup/cash/hermit/gradle/GradleConfigUpdater.kt
+++ b/src/main/kotlin/com/squareup/cash/hermit/gradle/GradleConfigUpdater.kt
@@ -14,6 +14,10 @@ import org.jetbrains.plugins.gradle.settings.GradleProjectSettings
 class GradleConfigUpdater : HermitPropertyHandler {
     private val log: Logger = Logger.getInstance(this.javaClass)
 
+    private fun notifyGradleUpdate(project: Project, name: String) {
+        UI.showInfo(project, "Hermit", "Switching to Gradle ${name}")
+    }
+
     override fun handle(hermitPackage: HermitPackage, project: Project) {
         if (hermitPackage.type == PackageType.Gradle) {
             val settings = GradleUtils.findGradleProjectSettings(project)
@@ -24,13 +28,14 @@ class GradleConfigUpdater : HermitPropertyHandler {
                     newSettings.gradleHome = hermitPackage.path
                     newSettings.distributionType = DistributionType.LOCAL
                     GradleUtils.insertNewProjectSettings(project, newSettings)
+                    notifyGradleUpdate(project, hermitPackage.displayName())
                 } else if (!isUpToDate(settings, hermitPackage)) {
                     log.debug("updating project (" + project.name + ")  gradle config to " + hermitPackage.logString())
                     settings.gradleHome = hermitPackage.path
                     settings.distributionType = DistributionType.LOCAL
+                    notifyGradleUpdate(project, hermitPackage.displayName())
                 }
             }
-            UI.showInfo(project, "Hermit", "Switching to Gradle ${hermitPackage.displayName()}")
         } else if (hermitPackage.type == PackageType.JDK) {
             // If the project uses a Hermit managed JDK, use the project JDK with Gradle
             // The project JDK is set accordingly in the HermitJdkUpdater


### PR DESCRIPTION
Previously, any change to the `bin/` directory would cause a Hermit refresh. Now, only update if a package symlink or a Hermit script file has changed.

Additionally, fixes a bug where any Hermit refresh would notify on Gradle version. Now, only show the notification when Gradle version actually changes.