### PR TITLE
Correctly detect `bin` dir creation.

### DIFF
--- a/src/main/kotlin/com/squareup/cash/hermit/HermitVFSChangeListener.kt
+++ b/src/main/kotlin/com/squareup/cash/hermit/HermitVFSChangeListener.kt
@@ -31,16 +31,17 @@ class HermitVFSChangeListener : BulkFileListener {
     private fun isHermitChange(project: Project, file: VirtualFile): Boolean {
         val root = project.guessProjectDir()
         // Check if we are in a bin/ directory
-        if (root == null || file.parent == null || file.parent.name != "bin") {
+        if (root == null || file.parent == null || (file.parent.name != "bin" && file.name != "bin")) {
             return false
         }
         // Check if we are at root bin/ directory
-        if (file.parent.parent != null && file.parent.parent != root) {
+        if (file.parent.parent != null && file.parent.parent != root && file.parent != root) {
             return false
         }
         val isPackageChange = file.name.endsWith(".pkg") && file.name.startsWith(".")
         val isHermitScriptChange = file.name == "hermit" || file.name == "hermit.hcl"
+        val isHermitBinCreation = file.name == "bin"
 
-        return isPackageChange || isHermitScriptChange
+        return isPackageChange || isHermitScriptChange || isHermitBinCreation
     }
 }

--- a/src/test/kotlin/com/squareup/cash/hermit/HermitProjectTestCase.kt
+++ b/src/test/kotlin/com/squareup/cash/hermit/HermitProjectTestCase.kt
@@ -32,4 +32,12 @@ abstract class HermitProjectTestCase : JavaProjectTestCase() {
     protected fun waitAppThreads() {
         waitForAppLeakingThreads(1000, TimeUnit.MILLISECONDS)
     }
+
+    override fun setUpProject() {
+        super.setUpProject()
+
+        // Create the project root dir
+        Files.createDirectories(projectDirOrFile.parent)
+        updateVFS()
+    }
 }

--- a/src/test/kotlin/com/squareup/cash/hermit/PluginIntegrationTest.kt
+++ b/src/test/kotlin/com/squareup/cash/hermit/PluginIntegrationTest.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.application.runWriteActionAndWait
 import com.intellij.openapi.externalSystem.service.execution.ExternalSystemJdkUtil
+import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.projectRoots.ProjectJdkTable
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.wm.WindowManager
@@ -16,6 +17,7 @@ import com.squareup.cash.hermit.ui.statusbar.HermitStatusBarPresentation
 import com.squareup.cash.hermit.ui.statusbar.HermitStatusBarWidget
 import junit.framework.TestCase
 import org.junit.Test
+import java.nio.file.Files
 
 class PluginIntegrationTest : HermitProjectTestCase() {
     @Test fun `test it negatively detects hermit correctly`() {
@@ -47,7 +49,12 @@ class PluginIntegrationTest : HermitProjectTestCase() {
 
     @Test fun `test it works if hermit is initialised after opening`() {
         Hermit(project).open()
+        TestCase.assertEquals(false, Hermit(project).hasHermit())
+
         withHermit(FakeHermit(listOf(TestPackage("name", "version", "", "root", mapOf(Pair("FOO", "BAR"))))))
+        waitAppThreads()
+        TestCase.assertEquals(true, Hermit(project).hasHermit())
+
         Hermit(project).enable()
         waitAppThreads()
 


### PR DESCRIPTION
Previously we were only detecting file changes under the bin dir, but if the bin dir is created in single VFS update, we only get the topmost update.

Also fixes the integration test testing this.