### PR TITLE
Handle Channel updates properly

### DIFF
--- a/src/main/kotlin/com/squareup/cash/hermit/goland/GoSdkExtensions.kt
+++ b/src/main/kotlin/com/squareup/cash/hermit/goland/GoSdkExtensions.kt
@@ -7,8 +7,11 @@ import com.intellij.openapi.project.Project
 import com.squareup.cash.hermit.HermitPackage
 
 fun HermitPackage.setSdk(project: Project): GoSdk {
-    val new = GoSdkImpl("file://" + this.path, this.version, this.path + "/src/runtime/internal/sys/zversion.go")
+    val new = GoSdkImpl(this.goURL(), this.version, this.path + "/src/runtime/internal/sys/zversion.go")
     GoSdkService.getInstance(project).setSdk(new)
     return new
 }
 
+fun HermitPackage.goURL(): String {
+    return "file://" + this.path
+}

--- a/src/main/kotlin/com/squareup/cash/hermit/goland/HermitGoEnvUpdater.kt
+++ b/src/main/kotlin/com/squareup/cash/hermit/goland/HermitGoEnvUpdater.kt
@@ -20,6 +20,7 @@ class HermitGoEnvUpdater : HermitPropertyHandler {
 
             if (
                 hermitPackage.version != sdk.version
+                || hermitPackage.goURL() != sdk.homeUrl
                 // If the current sdk has the same version,but it was not available before Hermit downloaded it,
                 // set it again to force re-indexing, and marking it as a valid one
                 || !sdk.isValid

--- a/src/main/kotlin/com/squareup/cash/hermit/idea/HermitJdkUpdater.kt
+++ b/src/main/kotlin/com/squareup/cash/hermit/idea/HermitJdkUpdater.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.projectRoots.ProjectJdkTable
 import com.squareup.cash.hermit.*
 
 @Service
@@ -19,6 +20,12 @@ class HermitJdkUpdater : HermitPropertyHandler {
                    hermitPackage.getSdk().setForProject(project)
                }
                UI.showInfo(project, "Hermit", "Switching to SDK ${hermitPackage.displayName()}")
+           }
+           if (projectSdk != null && hermitPackage.path != projectSdk.homePath) {
+               log.debug("updating (" + project.name + ") SDK (" + projectSdk.name + ") path from " + (projectSdk.homePath ?: "<null>") + " to " + hermitPackage.path)
+               ApplicationManager.getApplication()?.runWriteAction {
+                   ProjectJdkTable.getInstance().updateJdk(projectSdk, hermitPackage.newSdk())
+               }
            }
        }
     }


### PR DESCRIPTION
Previously, if an existing JDK had been created with a given name, its path was not updated even if the underlying Hermit package changed