### PR TITLE
Correctly set JDK versions for channels

### DIFF
--- a/src/main/kotlin/com/squareup/cash/hermit/ProjectExtensions.kt
+++ b/src/main/kotlin/com/squareup/cash/hermit/ProjectExtensions.kt
@@ -118,6 +118,7 @@ private fun Project.runHermit(vararg args: String): Result<Process> {
     val binDir = this.binDir()?.toNioPath()?.toFile()
     val commandLine = GeneralCommandLine(cmd, *args)
     commandLine.workDirectory = binDir
+    commandLine.environment["HERMIT_ENV"] = binDir?.parent
     val process = commandLine.createProcess()
     val exitCode = try {
         process.waitFor()

--- a/src/main/kotlin/com/squareup/cash/hermit/idea/JdkExtensions.kt
+++ b/src/main/kotlin/com/squareup/cash/hermit/idea/JdkExtensions.kt
@@ -1,10 +1,10 @@
 package com.squareup.cash.hermit.idea
 
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.projectRoots.JavaSdk
 import com.intellij.openapi.projectRoots.ProjectJdkTable
 import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.projectRoots.impl.JavaSdkImpl
-import com.intellij.openapi.projectRoots.impl.ProjectJdkImpl
 import com.intellij.openapi.roots.ProjectRootManager
 import com.squareup.cash.hermit.HermitPackage
 
@@ -12,20 +12,10 @@ fun Sdk.setForProject(project: Project) {
     ProjectRootManager.getInstance(project).projectSdk = this
 }
 
-fun HermitPackage.getSdk(): Sdk {
-    val installed = findInstalledSdk()
-    if (installed != null) {
-        return installed
-    }
-    val sdk = this.newSdk()
-    ProjectJdkTable.getInstance().addJdk(sdk)
-    return sdk
-}
-
 fun HermitPackage.newSdk(): Sdk {
-    val type = JavaSdkImpl()
-    val sdk = ProjectJdkImpl(sdkName(), type, path, version)
-    type.setupSdkPaths(sdk)
+    val jdkType = JavaSdkImpl.getInstance()
+    val sdk = JavaSdk.getInstance().createJdk(sdkName(), path)
+    //jdkType.setupSdkPaths(sdk)
     return sdk
 }
 

--- a/src/main/kotlin/com/squareup/cash/hermit/idea/JdkExtensions.kt
+++ b/src/main/kotlin/com/squareup/cash/hermit/idea/JdkExtensions.kt
@@ -4,7 +4,6 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.projectRoots.JavaSdk
 import com.intellij.openapi.projectRoots.ProjectJdkTable
 import com.intellij.openapi.projectRoots.Sdk
-import com.intellij.openapi.projectRoots.impl.JavaSdkImpl
 import com.intellij.openapi.roots.ProjectRootManager
 import com.squareup.cash.hermit.HermitPackage
 
@@ -13,10 +12,7 @@ fun Sdk.setForProject(project: Project) {
 }
 
 fun HermitPackage.newSdk(): Sdk {
-    val jdkType = JavaSdkImpl.getInstance()
-    val sdk = JavaSdk.getInstance().createJdk(sdkName(), path)
-    //jdkType.setupSdkPaths(sdk)
-    return sdk
+    return JavaSdk.getInstance().createJdk(sdkName(), path)
 }
 
 fun HermitPackage.findInstalledSdk(): Sdk? {


### PR DESCRIPTION
Uses 
```
JavaSdk.getInstance().createJdk
```
To create the new SDKs instead of manually instantiating the `ProjectJDKImpl`. This detects automatically the JDK version from the JDK dir. Previously on channels, the version was not set correctly.

Also, fixes an issue where if running the IDE from a Hermit environment, that environment could override the versions of detected packages.

Adds an integration test using real hermit to install packages.