### PR TITLE
check if project is trusted before enabling

### DIFF
--- a/src/main/kotlin/com/squareup/cash/hermit/Hermit.kt
+++ b/src/main/kotlin/com/squareup/cash/hermit/Hermit.kt
@@ -72,9 +72,17 @@ object Hermit {
                     log.debug(project.name + ": hermit disabled in the project")
                     setStatus(HermitStatus.Disabled)
                     when (project.isTrustedForHermit()) {
-                        ThreeState.YES -> { this.enable() }
-                        ThreeState.NO -> { /* do nothing */ }
-                        ThreeState.UNSURE -> { UI.askToEnableHermit(project) }
+                        ThreeState.YES -> { 
+                            log.debug(project.name + ": project trusted, enabling")
+                            this.enable()
+                         }
+                        ThreeState.NO -> { 
+                            log.debug(project.name + ": project not trusted, skipping")
+                        }
+                        ThreeState.UNSURE -> { 
+                            log.debug(project.name + ": cannot verify if project can be trusted, asking user instead")
+                            UI.askToEnableHermit(project) 
+                        }
                     }
                 }
             } else if (!this.isHermitProject) {

--- a/src/main/kotlin/com/squareup/cash/hermit/Hermit.kt
+++ b/src/main/kotlin/com/squareup/cash/hermit/Hermit.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.WindowManager
 import com.intellij.openapi.wm.impl.status.widget.StatusBarWidgetsManager
+import com.intellij.util.ThreeState
 import com.squareup.cash.hermit.action.BackgroundableWrapper
 import com.squareup.cash.hermit.ui.statusbar.HermitStatusBarWidget
 import com.squareup.cash.hermit.ui.statusbar.HermitStatusBarWidgetFactory
@@ -70,7 +71,11 @@ object Hermit {
                 } else {
                     log.debug(project.name + ": hermit disabled in the project")
                     setStatus(HermitStatus.Disabled)
-                    UI.askToEnableHermit(project)
+                    when (project.isTrustedForHermit()) {
+                        ThreeState.YES -> { this.enable() }
+                        ThreeState.NO -> { /* do nothing */ }
+                        ThreeState.UNSURE -> { UI.askToEnableHermit(project) }
+                    }
                 }
             } else if (!this.isHermitProject) {
                 log.debug(project.name + ": no hermit detected for " + project.name)

--- a/src/main/kotlin/com/squareup/cash/hermit/ProjectExtensions.kt
+++ b/src/main/kotlin/com/squareup/cash/hermit/ProjectExtensions.kt
@@ -18,6 +18,7 @@ import com.intellij.util.ThreeState
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.*
 import java.io.BufferedReader
+import java.lang.reflect.InvocationTargetException
 
 /**
  * Does the project have a hermit installation?
@@ -150,6 +151,16 @@ fun Project.isTrustedForHermit(): ThreeState {
 
         return ThreeState.fromBoolean(result)
     } catch (e: Exception) {
-        return ThreeState.UNSURE
+        when(e) {
+            is ClassNotFoundException,
+            is IllegalAccessException,
+            is IllegalArgumentException,
+            is InvocationTargetException -> {
+                return ThreeState.UNSURE
+            }
+            else -> {
+                throw e
+            }
+        }
     }
 }

--- a/src/main/kotlin/com/squareup/cash/hermit/UI.kt
+++ b/src/main/kotlin/com/squareup/cash/hermit/UI.kt
@@ -1,9 +1,12 @@
 package com.squareup.cash.hermit
 
+import com.intellij.ide.BrowserUtil
 import com.intellij.notification.Notification
+import com.intellij.notification.NotificationAction
 import com.intellij.notification.NotificationType
 import com.intellij.notification.Notifications
 import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.Project
 
 object UI {
@@ -28,6 +31,20 @@ object UI {
             NotificationType.INFORMATION
         ).addAction(actions.getAction(ActionID.enableHermit))
          .addAction(actions.getAction(ActionID.dontEnableHermit))
+
+        Notifications.Bus.notify(notification, project)
+    }
+
+    fun explainProjectIsNotTrusted(project: Project) {
+        val message = "Untrusted Project: Running in safe mode."
+        val notification = Notification("", "Hermit", message, NotificationType.ERROR)
+
+        notification.addAction(object : NotificationAction("More Information") {
+            override fun actionPerformed(e: AnActionEvent, notification: Notification) {
+                BrowserUtil.open("https://www.jetbrains.com/help/idea/project-security.html")
+                notification.expire()
+            }
+        })
 
         Notifications.Bus.notify(notification, project)
     }

--- a/src/main/kotlin/com/squareup/cash/hermit/UI.kt
+++ b/src/main/kotlin/com/squareup/cash/hermit/UI.kt
@@ -36,7 +36,7 @@ object UI {
     }
 
     fun explainProjectIsNotTrusted(project: Project) {
-        val message = "Untrusted Project: Running in safe mode."
+        val message = "Untrusted Project: hermit disabled."
         val notification = Notification("", "Hermit", message, NotificationType.ERROR)
 
         notification.addAction(object : NotificationAction("More Information") {

--- a/src/main/kotlin/com/squareup/cash/hermit/ui/statusbar/HermitStatusBarPresentation.kt
+++ b/src/main/kotlin/com/squareup/cash/hermit/ui/statusbar/HermitStatusBarPresentation.kt
@@ -1,6 +1,7 @@
 package com.squareup.cash.hermit.ui.statusbar
 
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.StatusBarWidget
 import com.intellij.util.Consumer
@@ -11,6 +12,8 @@ import com.squareup.cash.hermit.isTrustedForHermit
 import java.awt.event.MouseEvent
 
 class HermitStatusBarPresentation(val project: Project) : StatusBarWidget.TextPresentation {
+  private val log: Logger = Logger.getInstance(this.javaClass)
+
   override fun getTooltipText(): String? {
     return "Hermit status"
   }
@@ -21,9 +24,18 @@ class HermitStatusBarPresentation(val project: Project) : StatusBarWidget.TextPr
         val status = Hermit(project).hermitStatus()
         if (status == Hermit.HermitStatus.Disabled) {
           when (project.isTrustedForHermit()) {
-            ThreeState.YES -> { Hermit(project).enable() }
-            ThreeState.NO -> { UI.explainProjectIsNotTrusted(project) }
-            ThreeState.UNSURE -> { UI.askToEnableHermit(project) }
+            ThreeState.YES -> {
+              log.debug(project.name + ": project trusted, enabling")
+              Hermit(project).enable() 
+            }
+            ThreeState.NO -> {
+              log.debug(project.name + ": project not trusted, explaining why")
+              UI.explainProjectIsNotTrusted(project)
+            }
+            ThreeState.UNSURE -> {
+              log.debug(project.name + ": cannot verify if project can be trusted, asking user instead")
+              UI.askToEnableHermit(project)
+            }
           }
         } else if (status == Hermit.HermitStatus.Failed) {
           ApplicationManager.getApplication().invokeLater {

--- a/src/test/kotlin/com/squareup/cash/hermit/PluginIntegrationTest.kt
+++ b/src/test/kotlin/com/squareup/cash/hermit/PluginIntegrationTest.kt
@@ -150,18 +150,6 @@ class PluginIntegrationTest : HermitProjectTestCase() {
         TestCase.assertEquals("Hermit enabled", presentation.text)
     }
 
-    @Test fun `test it shows the Hermit status as disabled if Hermit is not enabled for the project`() {
-        withHermit(FakeHermit(listOf(
-            TestPackage("foo", "1.0", "","/root", emptyMap())
-        )))
-        Hermit(project).open()
-        waitAppThreads()
-
-        val widget = WindowManager.getInstance().getStatusBar(project)?.getWidget(HermitStatusBarWidget.ID)!!
-        val presentation = widget.presentation as HermitStatusBarPresentation
-        TestCase.assertEquals("Hermit disabled", presentation.text)
-    }
-
     @Test fun `test it shows the Hermit status as failed if Hermit execution fails when opening the project`() {
         withHermit(BrokenHermit)
         Hermit(project).open()


### PR DESCRIPTION
Fixes https://github.com/cashapp/hermit-ij-plugin/issues/37

* This is using reflection, as the API is not available publicly yet.
* When we load the project, we check if it was trusted, and if so, we enable Hermit directly.
* Otherwise, we disable Hermit, and If the user clicked the status bar entry, we will show the message below.
* Clicking `More Information` will take you to https://www.jetbrains.com/help/idea/project-security.html

![image](https://user-images.githubusercontent.com/15987992/164719825-b01761f3-a090-4247-a1ba-63a8aaa4eb16.png)

### Open Questions

1. I tested this on the earliest version I see (`2021.1.3` released on `2021/06/28` almost a year ago). But it still has the API, so I'm not sure how it would behave on much older versions that don't have it. Regardless, the entire call is wrapped in a `try / catch`, as we should change the user flow if reflection fails for any reason.
2. In the current setup, we can no longer unit test the start up scenario, since the reflected API cannot be controlled from tests. Thoughts on this? is there some IJ mocking/testing API that I might have missed?