### PR TITLE
Update gradle plugin to 1.5.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,6 @@ jobs:
       - name: Init Hermit
         run: ./bin/hermit env -r >> $GITHUB_ENV
       - name: Test
-        run: gradle test --info
+        run: gradle clean test --info
       - name: Plugin verification
-        run: gradle runPluginVerifier
+        run: gradle clean runPluginVerifier

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ import org.jetbrains.intellij.tasks.RunPluginVerifierTask
 plugins {
     id "idea"
     id "java"
-    id 'org.jetbrains.intellij' version '1.1.4'
+    id 'org.jetbrains.intellij' version '1.5.3'
     id 'org.jetbrains.kotlin.jvm' version '1.6.0'
     id 'org.jetbrains.kotlin.plugin.serialization' version '1.4.32'
 }


### PR DESCRIPTION
older versions no longer work with `runIde` task on newer IJ releases