### PR TITLE
Pause Gradle initialisation until Hermit has installed all packages.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,8 @@ def GO_VERSION = '221.5080.224'
 // Unfortunately the GoLand releases do not completely match the Go plugin releases
 def GO_PLUGIN_VERSION = IIC_VERSION
 // Test that the plugin still works on old releases
-def IIC_FROM_VERSION = '203.6682.168'
-def GO_FROM_VERSION = '203.6682.164'
+def IIC_FROM_VERSION = '212.4746.92'
+def GO_FROM_VERSION = '212.4746.93'
 
 group 'com.squareup.cash.hermit'
 version project.getProperties().getOrDefault("version", '1.0-SNAPSHOT')
@@ -68,8 +68,11 @@ runPluginVerifier {
     ideVersions = ['IIC-' + IIC_FROM_VERSION, 'GO-' + GO_FROM_VERSION, 'IIC-'+ IIC_VERSION, 'GO-' + GO_VERSION]
     failureLevel = EnumSet.complementOf(
             EnumSet.of(
-                    // skipping missing dependencies as com.intellij.java provided bi IJ raises a false warning
-                    RunPluginVerifierTask.FailureLevel.MISSING_DEPENDENCIES
+                    // skipping missing dependencies as com.intellij.java provided by IJ raises a false warning
+                    RunPluginVerifierTask.FailureLevel.MISSING_DEPENDENCIES,
+                    // skipping experimental API usage, as delaying Gradle execution relies on experimental GradleExecutionAware.
+                    // if the API changes, we should be able to detect that in our tests when a new version comes out.
+                    RunPluginVerifierTask.FailureLevel.EXPERIMENTAL_API_USAGES
             )
     )
 

--- a/src/main/kotlin/com/squareup/cash/hermit/Hermit.kt
+++ b/src/main/kotlin/com/squareup/cash/hermit/Hermit.kt
@@ -22,9 +22,10 @@ object Hermit {
     private val log: Logger = Logger.getInstance(this.javaClass)
 
     enum class HermitStatus {
-        Disabled,
-        Enabled,
-        Failed
+        Disabled, // Hermit is not in use
+        Installing, // Installing Hermit packages to the system
+        Enabled, // Hermit has been started correctly
+        Failed // Hermit initialisation has failed
     }
 
     private val HANDLER_EP_NAME: ExtensionPointName<HermitPropertyHandler> =
@@ -92,6 +93,7 @@ object Hermit {
 
         private fun runInstall() {
             log.info("installing hermit packages")
+            setStatus(HermitStatus.Installing)
             val task = BackgroundableWrapper(project, "Installing Hermit Packages", Runnable {
                 when (val result = project.installHermitPackages()) {
                     is Failure -> {

--- a/src/main/kotlin/com/squareup/cash/hermit/gradle/HermitGradleExecutionAware.kt
+++ b/src/main/kotlin/com/squareup/cash/hermit/gradle/HermitGradleExecutionAware.kt
@@ -1,0 +1,47 @@
+package com.squareup.cash.hermit.gradle
+
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.externalSystem.model.task.ExternalSystemTask
+import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskNotificationListener
+import com.intellij.openapi.project.Project
+import com.squareup.cash.hermit.Hermit
+import org.jetbrains.annotations.ApiStatus
+import org.jetbrains.plugins.gradle.service.execution.GradleExecutionAware
+
+class HermitGradleExecutionAware: GradleExecutionAware {
+  private val log: Logger = Logger.getInstance(this.javaClass)
+
+  override fun prepareExecution(
+    task: ExternalSystemTask,
+    externalProjectPath: String,
+    isPreviewMode: Boolean,
+    taskNotificationListener: ExternalSystemTaskNotificationListener,
+    project: Project
+  ) {
+    // If hermit is installing packages, pause the Gradle initialisation thread until the installation is done.
+    // This prevents Gradle failing for invalid JDK if the underlying JDK is not available on the disk when the project
+    // is opened.
+    if (Hermit(project).hermitStatus() == Hermit.HermitStatus.Installing) {
+      log.debug("waiting for 'hermit install' to be finished before continuing with Gradle preparation")
+
+      val start = System.currentTimeMillis()
+      var waitMS = 10L
+      while (true) {
+        Thread.sleep(waitMS)
+        if (Hermit(project).hermitStatus() != Hermit.HermitStatus.Installing) {
+          break
+        }
+        if (waitMS < 500L) waitMS *= 2
+        if (System.currentTimeMillis() - start > TIMEOUT_MS) {
+          log.warn("timed out while waiting for 'hermit install' to finish")
+          break
+        }
+      }
+      log.debug("done waiting for 'hermit install'")
+    }
+  }
+
+  companion object {
+    const val TIMEOUT_MS = 120000
+  }
+}

--- a/src/main/kotlin/com/squareup/cash/hermit/ui/statusbar/HermitStatusBarPresentation.kt
+++ b/src/main/kotlin/com/squareup/cash/hermit/ui/statusbar/HermitStatusBarPresentation.kt
@@ -33,6 +33,7 @@ class HermitStatusBarPresentation(val project: Project) : StatusBarWidget.TextPr
       Hermit.HermitStatus.Enabled -> "Hermit enabled"
       Hermit.HermitStatus.Disabled -> "Hermit disabled"
       Hermit.HermitStatus.Failed -> "Hermit failed"
+      Hermit.HermitStatus.Installing -> "Hermit installing"
     }
   }
 

--- a/src/main/resources/META-INF/gradle.xml
+++ b/src/main/resources/META-INF/gradle.xml
@@ -4,6 +4,10 @@
         <executionEnvironmentProvider implementation="com.squareup.cash.hermit.execution.HermitGradleTaskEnvProvider" order="first" />
     </extensions>
 
+    <extensions defaultExtensionNs="com.intellij">
+        <externalExecutionAware id="hermit-gradle" key="GRADLE" implementationClass="com.squareup.cash.hermit.gradle.HermitGradleExecutionAware" order="first"/>
+    </extensions>
+
     <extensions defaultExtensionNs="org.squareup.cash.hermit.idea-plugin">
         <property-handler implementation="com.squareup.cash.hermit.gradle.GradleConfigUpdater" />
     </extensions>


### PR DESCRIPTION
This prevents errors of Invalid JDK when a user opens a project referring to a hermit managed JDK that is not on disk yet.

This also adds a new hermit status: installing

Closes https://github.com/cashapp/hermit-ij-plugin/issues/33

`GradleExecutionAware`s are run in a single thread sequentially. So, we can just register one before the main initialiser that verifies the Gradle JVM, and pause the thread until Hermit has finished running.

This API was only introduced in `2021.2.1` release released on 7/2021. So, unfortunately, we must drop updates to older IntelliJ versions to enable this.