### PR TITLE
major version upgrade

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,18 +3,18 @@ import org.jetbrains.intellij.tasks.RunPluginVerifierTask
 plugins {
     id "idea"
     id "java"
-    id 'org.jetbrains.intellij' version '1.10.0'
-    id 'org.jetbrains.kotlin.jvm' version '1.6.0'
+    id 'org.jetbrains.intellij' version '1.13.3'
+    id 'org.jetbrains.kotlin.jvm' version '1.8.10'
     id 'org.jetbrains.kotlin.plugin.serialization' version '1.4.32'
 }
 
 ext {
-    kotlin_version = '1.4.32'
+    kotlin_version = '1.8.10'
 }
 
 // The latest supported versions. Note, these are updated automatically from update-major-versions.sh
-def IIC_VERSION = '223.7571.182'
-def GO_VERSION = '222.3345.118'
+def IIC_VERSION = '231.8109.175'
+def GO_VERSION = '223.8836.56'
 // Unfortunately the GoLand releases do not completely match the Go plugin releases
 def GO_PLUGIN_VERSION = IIC_VERSION
 // The oldest supported versions.

--- a/src/main/kotlin/com/squareup/cash/hermit/Hermit.kt
+++ b/src/main/kotlin/com/squareup/cash/hermit/Hermit.kt
@@ -8,9 +8,7 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.extensions.ExtensionPointName
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.wm.StatusBarWidgetFactory
 import com.intellij.openapi.wm.WindowManager
-import com.intellij.openapi.wm.impl.status.widget.StatusBarWidgetSettings
 import com.intellij.openapi.wm.impl.status.widget.StatusBarWidgetsManager
 import com.intellij.util.ThreeState
 import com.squareup.cash.hermit.action.BackgroundableWrapper
@@ -33,7 +31,7 @@ object Hermit {
     }
 
     private val HANDLER_EP_NAME: ExtensionPointName<HermitPropertyHandler> =
-        ExtensionPointName.create<HermitPropertyHandler>("org.squareup.cash.hermit.idea-plugin.property-handler")
+        ExtensionPointName("org.squareup.cash.hermit.idea-plugin.property-handler")
 
     private val projects = ConcurrentHashMap<String, State>()
 
@@ -75,7 +73,6 @@ object Hermit {
             if (this.isHermitProject) {
                 log.info("enabling Hermit for " + project.name)
                 this.isHermitOpened = true
-
                 if (hermitEnabled) {
                     log.debug(project.name + ": hermit enabled in the project")
                     this.runInstall()
@@ -150,8 +147,7 @@ object Hermit {
             ApplicationManager.getApplication().invokeLater {
                 statusBarWidgetsManager.updateWidget(HermitStatusBarWidgetFactory::class.java)
 
-                val statusbar = WindowManager.getInstance().getStatusBar(project)
-                statusbar?.updateWidget(HermitStatusBarWidget.ID)
+                WindowManager.getInstance().getStatusBar(project)?.updateWidget(HermitStatusBarWidget.ID)
             }
         }
 

--- a/src/main/kotlin/com/squareup/cash/hermit/Hermit.kt
+++ b/src/main/kotlin/com/squareup/cash/hermit/Hermit.kt
@@ -8,7 +8,9 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.extensions.ExtensionPointName
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.StatusBarWidgetFactory
 import com.intellij.openapi.wm.WindowManager
+import com.intellij.openapi.wm.impl.status.widget.StatusBarWidgetSettings
 import com.intellij.openapi.wm.impl.status.widget.StatusBarWidgetsManager
 import com.intellij.util.ThreeState
 import com.squareup.cash.hermit.action.BackgroundableWrapper
@@ -73,6 +75,7 @@ object Hermit {
             if (this.isHermitProject) {
                 log.info("enabling Hermit for " + project.name)
                 this.isHermitOpened = true
+
                 if (hermitEnabled) {
                     log.debug(project.name + ": hermit enabled in the project")
                     this.runInstall()
@@ -147,7 +150,8 @@ object Hermit {
             ApplicationManager.getApplication().invokeLater {
                 statusBarWidgetsManager.updateWidget(HermitStatusBarWidgetFactory::class.java)
 
-                WindowManager.getInstance().getStatusBar(project)?.updateWidget(HermitStatusBarWidget.ID)
+                val statusbar = WindowManager.getInstance().getStatusBar(project)
+                statusbar?.updateWidget(HermitStatusBarWidget.ID)
             }
         }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -39,7 +39,7 @@
 
     <extensions defaultExtensionNs="com.intellij">
         <toolsCustomizer implementation="com.squareup.cash.hermit.execution.HermitToolsCustomiser" />
-        <statusBarWidgetFactory implementation="com.squareup.cash.hermit.ui.statusbar.HermitStatusBarWidgetFactory"/>
+        <statusBarWidgetFactory id="HermitStatusBarWidgetFactory" implementation="com.squareup.cash.hermit.ui.statusbar.HermitStatusBarWidgetFactory"/>
     </extensions>
 
     <extensionPoints>

--- a/src/test/kotlin/com/squareup/cash/hermit/PluginIntegrationTest.kt
+++ b/src/test/kotlin/com/squareup/cash/hermit/PluginIntegrationTest.kt
@@ -146,8 +146,8 @@ class PluginIntegrationTest : HermitProjectTestCase() {
         waitAppThreads()
 
         val widget = WindowManager.getInstance().getStatusBar(project)?.getWidget(HermitStatusBarWidget.ID)!!
-        val presentation = widget.presentation as HermitStatusBarPresentation
-        TestCase.assertEquals("Hermit enabled", presentation.text)
+        val presentation = widget.getPresentation() as HermitStatusBarPresentation
+        TestCase.assertEquals("Hermit enabled", presentation.getText())
     }
 
     @Test fun `test it shows the Hermit status as failed if Hermit execution fails when opening the project`() {
@@ -157,8 +157,8 @@ class PluginIntegrationTest : HermitProjectTestCase() {
         waitAppThreads()
 
         val widget = WindowManager.getInstance().getStatusBar(project)?.getWidget(HermitStatusBarWidget.ID)!!
-        val presentation = widget.presentation as HermitStatusBarPresentation
-        TestCase.assertEquals("Hermit failed", presentation.text)
+        val presentation = widget.getPresentation() as HermitStatusBarPresentation
+        TestCase.assertEquals("Hermit failed", presentation.getText())
     }
 
     @Test fun `test it does not shows the Hermit status if there is no Hermit in the project`() {


### PR DESCRIPTION
Support for 231

This required a new version of `org.jetbrains.intellij` and kotlin, and some related fixes.
Also, statusbar widget XML configuration now requires the factory ID as `id = ` attribute, otherwise the statusbar is hidden.

Finally, after this update, ExtensionPointName.create was not found on all versions anymore. Changed that do a direct constructor call.