### PR TITLE
fix: get go plugin version separately

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,14 +62,14 @@ val products = listOf(
   Product(
     releaseType = "release",
     sdkVersion = properties["IIC.release.version"] as String,
-    goPluginVersion = properties["IIC.release.version"] as String,
+    goPluginVersion = properties["IIC.release.go_plugin.version"] as String,
     intellijVersion = properties["IIC.release.version"] as String,
     golandVersion = properties["GO.release.version"] as String,
   ),
   Product(
     releaseType = "eap",
     sdkVersion = "LATEST-EAP-SNAPSHOT",
-    goPluginVersion = properties["IIC.eap.version"] as String,
+    goPluginVersion = properties["IIC.eap.go_plugin.version"] as String,
     intellijVersion = properties["IIC.eap.version"] as String,
     golandVersion = properties["GO.eap.version"] as String,
   ),
@@ -77,8 +77,6 @@ val products = listOf(
 val product = products.first { it.releaseType == (System.getenv("RELEASE_TYPE") ?: "release") }
 
 intellij {
-  // Note: The IntelliJ version below needs to match the go plugin version as defined here:
-  // https://plugins.jetbrains.com/plugin/9568-go/versions
   version.set(product.sdkVersion)
   type.set("IU")
   plugins.set(
@@ -86,7 +84,7 @@ intellij {
       "gradle",
       "java",
       "terminal",
-      // This version is in sync with the IJ version, but not in sync with the GoLand version.
+      // This version is in sync with the IJ Ultimate version, not the GoLand version.
       "org.jetbrains.plugins.go:${product.goPluginVersion}",
       // Needed by Go plugin. See https://github.com/JetBrains/gradle-intellij-plugin/issues/1056
       "org.intellij.intelliLang"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,13 @@
 kotlin.code.style=official
 
 # The latest supported versions. Note, these are updated automatically from update-major-versions.sh
-IIC.release.version=231.8109.175
-IIC.eap.version=232.6095.10
-GO.release.version=231.8109.46
-GO.eap.version=232.6095.10
+IIC.release.version=231.9161.38
+IIC.eap.version=232.7754.73
+
+IIC.release.go_plugin.version=231.9161.14
+IIC.eap.go_plugin.version=232.7754.73
+GO.release.version=231.9161.41
+GO.eap.version=232.7754.71
 # The oldest supported versions.
 IIC.from.version=222.4554.10
 GO.from.version=222.4554.12


### PR DESCRIPTION
Because the plugin version may not match the IU release version.

Also reverts change to major version check since the new one doesn't work.