### PR TITLE
fix: use major version EAP snapshot when building EAP

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,7 +68,8 @@ val products = listOf(
   ),
   Product(
     releaseType = "eap",
-    sdkVersion = "LATEST-EAP-SNAPSHOT",
+    // "<major version>-EAP-SNAPSHOT"
+    sdkVersion = "${(properties["IIC.eap.version"] as String).split(".")[0]}-EAP-SNAPSHOT",
     goPluginVersion = properties["IIC.eap.go_plugin.version"] as String,
     intellijVersion = properties["IIC.eap.version"] as String,
     golandVersion = properties["GO.eap.version"] as String,
@@ -84,7 +85,6 @@ intellij {
       "gradle",
       "java",
       "terminal",
-      // This version is in sync with the IJ Ultimate version, not the GoLand version.
       "org.jetbrains.plugins.go:${product.goPluginVersion}",
       // Needed by Go plugin. See https://github.com/JetBrains/gradle-intellij-plugin/issues/1056
       "org.intellij.intelliLang"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,13 +1,13 @@
 kotlin.code.style=official
 
 # The latest supported versions. Note, these are updated automatically from update-major-versions.sh
-IIC.release.version=231.9161.38
-IIC.eap.version=232.7754.73
+IIC.release.version=232.8660.185
+IIC.eap.version=232.8660.48
 
-IIC.release.go_plugin.version=231.9161.14
-IIC.eap.go_plugin.version=232.7754.73
-GO.release.version=231.9161.41
-GO.eap.version=232.7754.71
+IIC.release.go_plugin.version=232.8660.142
+IIC.eap.go_plugin.version=232.8660.142
+GO.release.version=231.9225.16
+GO.eap.version=232.8660.55
 # The oldest supported versions.
 IIC.from.version=222.4554.10
 GO.from.version=222.4554.12


### PR DESCRIPTION
~~LATEST-EAP-SNAPSHOT was set to the stable release, causing the EAP build to fail.~~ LATEST-EAP-SNAPSHOT was set to a version incompatible with the currently-set snapshot version. Switching from LATEST to a major-version one will help catch this problem in the future, but we might have to reconsider upgrading major versions since the failure here is that 232.8* wasn't compatible with 232.7*.