### PR TITLE
fix: replace use of ProjectLocator with project access

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
   id("idea")
   id("java")
   kotlin("kapt") version "1.8.10"
-  id("org.jetbrains.intellij") version "1.13.3"
+  id("org.jetbrains.intellij") version "1.15.0"
   id("org.jetbrains.kotlin.jvm") version "1.8.10"
   id("org.jetbrains.kotlin.plugin.serialization") version "1.4.32"
 }
@@ -120,9 +120,6 @@ tasks {
     failureLevel.set(
       EnumSet.complementOf(
         EnumSet.of(
-          // skipping compatibility problems due to potential false positive with EAP v232:
-          // Method com.squareup.cash.hermit.HermitVFSChangeListener.after(List events) : void references an unresolved class com.intellij.openapi.project.ProjectLocator.Companion. This can lead to **NoSuchClassError** exception at runtime.
-          RunPluginVerifierTask.FailureLevel.COMPATIBILITY_PROBLEMS,
           // skipping missing dependencies as com.intellij.java provided by IJ raises a false warning
           RunPluginVerifierTask.FailureLevel.MISSING_DEPENDENCIES,
           // skipping experimental API usage, as delaying Gradle execution relies on experimental GradleExecutionAware.

--- a/src/main/kotlin/com/squareup/cash/hermit/Hermit.kt
+++ b/src/main/kotlin/com/squareup/cash/hermit/Hermit.kt
@@ -33,12 +33,12 @@ object Hermit {
     private val HANDLER_EP_NAME: ExtensionPointName<HermitPropertyHandler> =
         ExtensionPointName("org.squareup.cash.hermit.idea-plugin.property-handler")
 
-    private val projects = ConcurrentHashMap<String, State>()
+    private val projects = ConcurrentHashMap<String, HermitState>()
 
-    operator fun invoke(project: Project): State {
-        val state = project.projectFilePath?.let { projects.getOrPut(it, { State(project) }) }
+    operator fun invoke(project: Project): HermitState {
+        val hermitState = project.projectFilePath?.let { projects.getOrPut(it) { HermitState(project) } }
         // projectFilePath can be null for the default project. Return an empty state for it.
-        return state ?: State(project)
+        return hermitState ?: HermitState(project)
     }
 
     fun remove(project: Project) {
@@ -46,10 +46,12 @@ object Hermit {
         project.projectFilePath?.let { projects.remove(it) }
     }
 
+    fun allProjects(): Collection<HermitState> = projects.values
+
     /**
      * State maintains the Hermit state of a single project
      */
-    class State(private val project: Project) {
+    class HermitState(val project: Project) {
         // Is this project a hermit enabled project?
         private var isHermitProject = false
         // Has the project been opened in the plugin?


### PR DESCRIPTION
There was a compatibility problem tagged with ProjectLocator.

Iterating through all open projects seems a bit more expensive, but we're not doing a lot per iteration.