### PR TITLE
fix: delay setting state to enabled until all property handlers are done

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ This generates a zip file at
 To install the package, go to the plugin preferences in your IDE, and select "Install plugin from disk"
 If you then select the zip file generated above and restart your IDE, the plugin should be ready.
 
+## Developing locally
+
+You can use the `runIde` task to start an IDE with the plugin installed. You can also run that in debug mode.
+
 ---
 
 Copyright 2021 Square, Inc.

--- a/src/main/kotlin/com/squareup/cash/hermit/Hermit.kt
+++ b/src/main/kotlin/com/squareup/cash/hermit/Hermit.kt
@@ -129,8 +129,8 @@ object Hermit {
                         if (!project.isDisposed) {
                             // We need to enable hermit in a Write-enabled thread
                             ApplicationManager.getApplication().invokeLater {
-                                setStatus(HermitStatus.Enabled)
                                 Hermit(project).update()
+                                setStatus(HermitStatus.Enabled)
                             }
                         }
                     }
@@ -157,7 +157,7 @@ object Hermit {
             this.clear()
             this.isHermitProject = project.hasHermit()
 
-            if (this.isHermitProject && this.status == HermitStatus.Enabled) {
+            if (this.isHermitProject) {
                 log.info(project.name + ": updating hermit status from disk")
                 when(val res =  project.hermitProperties().flatMap { prop -> project.hermitVersion().map { Pair(it, prop) }}) {
                     is Failure -> {

--- a/src/main/kotlin/com/squareup/cash/hermit/ProjectExtensions.kt
+++ b/src/main/kotlin/com/squareup/cash/hermit/ProjectExtensions.kt
@@ -110,8 +110,9 @@ private fun hermitPackages(js: JsonElement): Result<List<HermitPackage>> {
                 val root = obj.field("Root").flatMap { it.asPrimitive() }.map { it.nullableString() }.bind()
                 val type = when(name) {
                     "go" -> PackageType.Go
-                    "openjdk" -> PackageType.JDK
+                    "corretto" -> PackageType.JDK
                     "graalvm" -> PackageType.JDK
+                    "openjdk" -> PackageType.JDK
                     "gradle" -> PackageType.Gradle
                     else -> PackageType.Unknown
                 }


### PR DESCRIPTION
This should make Gradle execution only happen after the Gradle configurer is done.

Also includes chore commits to recognise corretto as a JDK, and to document running locally