### PR TITLE
fix: add dep on properties plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -85,6 +85,7 @@ intellij {
       "gradle",
       "java",
       "terminal",
+      "com.intellij.properties",
       "org.jetbrains.plugins.go:${product.goPluginVersion}",
       // Needed by Go plugin. See https://github.com/JetBrains/gradle-intellij-plugin/issues/1056
       "org.intellij.intelliLang"

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -46,6 +46,7 @@
         <extensionPoint name="property-handler" interface="com.squareup.cash.hermit.HermitPropertyHandler" />
     </extensionPoints>
 
+    <depends optional="true" config-file="properties.xml">com.intellij.properties</depends>
     <depends optional="true" config-file="idea.xml">com.intellij.java</depends>
     <depends optional="true" config-file="gradle.xml">com.intellij.gradle</depends>
     <depends optional="true" config-file="goland.xml">org.jetbrains.plugins.go</depends>

--- a/src/main/resources/META-INF/properties.xml
+++ b/src/main/resources/META-INF/properties.xml
@@ -1,0 +1,1 @@
+<idea-plugin></idea-plugin>


### PR DESCRIPTION
looks like the 2023.3 eap needs it: https://youtrack.jetbrains.com/issue/IDEA-333586/Exception-Trying-to-add-extensions-to-non-registered-file-type-Properties-Plugin-com.intellij.java-in-tests