### PR TITLE
fix: do not run "hermit install" multiple times on a change if multiple windows are open

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,10 +2,10 @@ kotlin.code.style=official
 
 # The latest supported versions. Note, these are updated automatically from update-major-versions.sh
 IIC.release.version=233.14015.106
-IIC.eap.version=241.8102.112
+IIC.eap.version=241.14494.17
 
 IIC.release.go_plugin.version=233.14015.106
-IIC.eap.go_plugin.version=241.8102.112
+IIC.eap.go_plugin.version=241.14494.17
 GO.release.version=233.13135.104
 GO.eap.version=241.8102.131
 # The oldest supported versions.

--- a/src/main/kotlin/com/squareup/cash/hermit/HermitVFSChangeListener.kt
+++ b/src/main/kotlin/com/squareup/cash/hermit/HermitVFSChangeListener.kt
@@ -7,36 +7,34 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.newvfs.BulkFileListener
 import com.intellij.openapi.vfs.newvfs.events.VFileEvent
 
-class HermitVFSChangeListener : BulkFileListener {
+class HermitVFSChangeListener(val project: Project) : BulkFileListener {
     private val log: Logger = Logger.getInstance(this.javaClass)
 
     override fun after(events: MutableList<out VFileEvent>) {
-        val needsUpdating = HashMap<String, Project>()
+        var needsUpdating = false
         events.forEach {
             it.file?.let { file ->
                 log.debug("Checking if file [${file.path}] is in projects " +
-                        "${Hermit.allProjects().map { state -> state.project.name }}")
-                Hermit.allProjects().forEach { state ->
-                    val project = state.project
-                    // The project might have been disposed since looking up Hermit.allProjects.
-                    log.debug("Project [${project.name}] is disposed: [${project.isDisposed}]")
-                    if (!project.isDisposed && isHermitChange(project, file)) {
-                        log.debug("Project [${project.name}] needs updating")
-                        needsUpdating[project.name] = project
-                    }
+                    "${Hermit.allProjects().map { state -> state.project.name }}")
+                // The project might have been disposed since looking up Hermit.allProjects.
+                log.debug("Project [${project.name}] is disposed: [${project.isDisposed}]")
+                if (!project.isDisposed && isHermitChange(project, file)) {
+                    log.debug("Project [${project.name}] needs updating")
+                    needsUpdating = true
                 }
             }
         }
 
-        needsUpdating.forEach {
-            log.info("hermit configuration change detected at " + it.value.name)
-            Hermit(it.value).open()
-            Hermit(it.value).installAndUpdate()
+        if (needsUpdating) {
+            log.info("hermit configuration change detected at " + project.name)
+            Hermit(project).open()
+            Hermit(project).installAndUpdate()
         }
     }
 
     private fun isHermitChange(project: Project, file: VirtualFile): Boolean {
         val root = project.guessProjectDir()
+
         // Check if we are in a bin/ directory
         if (root == null || file.parent == null || (file.parent.name != "bin" && file.name != "bin")) {
             return false


### PR DESCRIPTION
It seems that as we were binding the project listeners without project constructors, all of them were triggered for all file events. This meant that if there was a change to Hermit environment, we would get "hermit install" executed as many times as there were open windows.