### PR TITLE
Update building this plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ All Hermit changes are automatically reflected in the IDE.
 
 To build the plugin, run
 
-    gradle buildPlugin
+```sh
+./gradlew buildPlugin
+```
 
 This generates a zip file at
 


### PR DESCRIPTION
It would be more convenient for new guys to run Gradle commands via `./gradlew` than `gradle`. Also, wrap this line with a shell code block, which supports running it in IDEA directly.

<img width="1237" alt="image" src="https://github.com/user-attachments/assets/7b29667c-1945-40ab-89c2-21c270eb7c2b" />
