### PR TITLE
chore: include extra diagnostics when hermit decides not to activate

### DIFF
--- a/src/main/kotlin/com/squareup/cash/hermit/Hermit.kt
+++ b/src/main/kotlin/com/squareup/cash/hermit/Hermit.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.extensions.ExtensionPointName
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.wm.WindowManager
 import com.intellij.openapi.wm.impl.status.widget.StatusBarWidgetsManager
 import com.intellij.util.ThreeState
@@ -96,7 +97,7 @@ object Hermit {
                     }
                 }
             } else {
-                log.info(project.name + ": no hermit detected for " + project.name)
+                log.info(project.name + ": no hermit detected for " + project.name + " (hermit not found in bin directory under " + project.guessProjectDir()?.path + ")")
                 setStatus(HermitStatus.Disabled)
             }
             this.refreshUI()


### PR DESCRIPTION
We've observed hermit not activating on projects where it should.  (specifically an internal Bazel project)

The problem appears to be in resolving the bin directory properly.  (`guessProjectDir` seems to be returning a directory other than the repository root)
This change outputs where it was trying to find hermit when it decided it wasn't a hermit project.

eg for a problematic project java, outputs:
```
java: no hermit detected for java (hermit not found in bin directory under /Users/<userid>/Development/java/.ijwb)
```