### PR TITLE
Set Gradle daemon launcher JVM to hermit JDK via settings.javaHome

### DIFF
--- a/src/main/kotlin/com/squareup/cash/hermit/gradle/HermitGradleEnvProvider.kt
+++ b/src/main/kotlin/com/squareup/cash/hermit/gradle/HermitGradleEnvProvider.kt
@@ -48,6 +48,15 @@ class HermitGradleEnvProvider : GradleTaskManagerExtension {
             if (env.isNotEmpty()) {
                 log.debug("injecting ${env.size} Hermit environment variables into $context")
                 settings.withEnvironmentVariables(env)
+
+                // Also set the Gradle daemon launcher JVM to the hermit JDK.
+                // withEnvironmentVariables only affects the env of the spawned process,
+                // but the IDE picks the JVM binary from settings.javaHome separately.
+                val javaHome = env["JAVA_HOME"]
+                if (javaHome != null) {
+                    log.debug("setting Gradle JVM home to $javaHome for $context")
+                    settings.javaHome = javaHome
+                }
             }
         }
     }

--- a/src/test/kotlin/com/squareup/cash/hermit/gradle/HermitGradleEnvProviderTest.kt
+++ b/src/test/kotlin/com/squareup/cash/hermit/gradle/HermitGradleEnvProviderTest.kt
@@ -52,6 +52,7 @@ class HermitGradleEnvProviderTest : HermitProjectTestCase() {
 
     assertEquals("/hermit/jdk/home", settings.env["JAVA_HOME"])
     assertEquals("/project/bin", settings.env["HERMIT_BIN"])
+    assertEquals("/hermit/jdk/home", settings.javaHome)
   }
 
   @Test fun `test configureTasks does not modify settings when hermit is not present`() {
@@ -59,6 +60,7 @@ class HermitGradleEnvProviderTest : HermitProjectTestCase() {
     provider.configureTasks("", taskId(), settings, null)
 
     assertTrue(settings.env.isEmpty())
+    assertNull(settings.javaHome)
   }
 
   @Test fun `test configureTasks does not modify settings when hermit has no env vars`() {
@@ -72,6 +74,7 @@ class HermitGradleEnvProviderTest : HermitProjectTestCase() {
     provider.configureTasks("", taskId(), settings, null)
 
     assertTrue(settings.env.isEmpty())
+    assertNull(settings.javaHome)
   }
 
   @Test fun `test configureTasks preserves existing env vars in settings`() {
@@ -89,6 +92,7 @@ class HermitGradleEnvProviderTest : HermitProjectTestCase() {
 
     assertEquals("/hermit/jdk/home", settings.env["JAVA_HOME"])
     assertEquals("existing_value", settings.env["EXISTING_VAR"])
+    assertEquals("/hermit/jdk/home", settings.javaHome)
   }
 
   @Test fun `test configureTasks overrides existing JAVA_HOME with hermit value`() {
@@ -102,9 +106,11 @@ class HermitGradleEnvProviderTest : HermitProjectTestCase() {
 
     val settings = GradleExecutionSettings()
     settings.withEnvironmentVariables(mapOf("JAVA_HOME" to "/user/old/jdk"))
+    settings.javaHome = "/ide/bundled/jbr"
     provider.configureTasks("", taskId(), settings, null)
 
     assertEquals("/hermit/jdk/home", settings.env["JAVA_HOME"])
+    assertEquals("/hermit/jdk/home", settings.javaHome)
   }
 
   @Test fun `test configureTasks injects multiple env vars from multiple packages`() {
@@ -143,6 +149,7 @@ class HermitGradleEnvProviderTest : HermitProjectTestCase() {
 
     assertEquals("/hermit/jdk/home", settings.env["JAVA_HOME"])
     assertEquals("/project", settings.env["HERMIT_ENV"])
+    assertEquals("/hermit/jdk/home", settings.javaHome)
   }
 
   @Test fun `test injectHermitEnvironment skips when hermit is not present`() {
@@ -150,6 +157,7 @@ class HermitGradleEnvProviderTest : HermitProjectTestCase() {
     HermitGradleEnvProvider.injectHermitEnvironment(project, settings, "test")
 
     assertTrue(settings.env.isEmpty())
+    assertNull(settings.javaHome)
   }
 
   @Test fun `test injectHermitEnvironment overrides existing JAVA_HOME`() {
@@ -163,8 +171,25 @@ class HermitGradleEnvProviderTest : HermitProjectTestCase() {
 
     val settings = GradleExecutionSettings()
     settings.withEnvironmentVariables(mapOf("JAVA_HOME" to "/user/old/jdk"))
+    settings.javaHome = "/ide/bundled/jbr"
     HermitGradleEnvProvider.injectHermitEnvironment(project, settings, "test")
 
     assertEquals("/hermit/jdk/home", settings.env["JAVA_HOME"])
+    assertEquals("/hermit/jdk/home", settings.javaHome)
+  }
+
+  @Test fun `test injectHermitEnvironment does not set javaHome when no JAVA_HOME in env`() {
+    withHermit(FakeHermit(listOf(
+      TestPackage("gradle", "9.3.1", "", "/gradle/path", mapOf(
+        "GRADLE_HOME" to "/hermit/gradle/home"
+      ))
+    )))
+    Hermit(project).enable()
+    waitAppThreads()
+
+    val settings = GradleExecutionSettings()
+    HermitGradleEnvProvider.injectHermitEnvironment(project, settings, "test")
+
+    assertNull(settings.javaHome)
   }
 }


### PR DESCRIPTION
PR #114 only injected `JAVA_HOME` as an environment variable via `withEnvironmentVariables()`. This is not sufficient because the IDE resolves the Gradle daemon launcher JVM from `GradleExecutionSettings.javaHome`, which is a separate field. When javaHome is unset, the IDE defaults to its bundled JBR. Gradle's daemon toolchain resolver (`gradle-daemon-jvm.properties`) then confirms the JBR as the best candidate because it's already the "current JVM" and matches the requested version, so the hermit JDK never gets a chance to win despite `JAVA_HOME` pointing to it.

Now we also set settings.javaHome from `JAVA_HOME` so the IDE forks the Gradle daemon with the hermit-managed JDK directly.

### Testing

Add debug print to `build.gradle`:

```groovy
logger.lifecycle("JAVA_HOME (env): ${System.getenv('JAVA_HOME') ?: '(not set)'}")
logger.lifecycle("java.home (prop): ${System.getProperty('java.home')}")
```

Run `killall java` to ensure no JVMs are running, then start an IDE sync. It prints this without the change in this PR:

```
JAVA_HOME (env): /Users/jfriend/Library/Java/JavaVirtualMachines/jdk-21.0.10_7-block-2024.jdk/Contents/Home
java.home (prop): /Users/jfriend/Applications/Android Studio.app/Contents/jbr/Contents/Home
```

With this PR:

```
JAVA_HOME (env): /Users/jfriend/Library/Java/JavaVirtualMachines/jdk-21.0.10_7-block-2024.jdk/Contents/Home
java.home (prop): /Users/jfriend/Library/Java/JavaVirtualMachines/jdk-21.0.10_7-block-2024.jdk/Contents/Home
```