### PR TITLE
Raise minimum supported IDE from 232 to 251

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,5 +9,5 @@ IIC.eap.go_plugin.version=251.17181.16
 GO.release.version=251.23774.430
 GO.eap.version=251.17181.28
 # The oldest supported versions.
-IIC.from.version=232.10335.12
-GO.from.version=232.10335.12
+IIC.from.version=251.23774.435
+GO.from.version=251.23774.430


### PR DESCRIPTION
Raise minimum supported IDE from 232 to 251 to fix plugin verifier compatibility issues with BuildLayoutParameters API changes. Compile against 261. Rename IIC properties to IJ for the unified IntelliJ distribution and use intellijIdea() dependency helper. Update upgrade-major-versions.sh accordingly.