### PR TITLE
Unpin pluginverifier version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,7 +63,6 @@ val arrowVersion = "0.11.0"
 dependencies {
   intellijPlatform {
     intellijIdeaUltimate(product.sdkVersion) { useInstaller = false }
-    pluginVerifier("1.378")
     plugins(
       "org.jetbrains.plugins.go:${product.goPluginVersion}"
     )


### PR DESCRIPTION
Jetbrains approval process for marketplace always runs on the latest version. Pinning the version here will mask potential verifier errors that wont be caught til submission to marketplace.