### PR TITLE
Revert stale hermit Gradle config to the wrapper

### DIFF
--- a/src/main/kotlin/com/squareup/cash/hermit/Hermit.kt
+++ b/src/main/kotlin/com/squareup/cash/hermit/Hermit.kt
@@ -175,7 +175,9 @@ object Hermit {
                             log.info(project.name + ": updating hermit status succeeded: " + res.value.second.logString())
                             this.properties = res.value.second
                             ApplicationManager.getApplication().invokeLater {
-                                res.value.second.packages.forEach { updateHandlers(it) }
+                                val packages = res.value.second.packages
+                                packages.forEach { updateHandlers(it) }
+                                reconcileHandlers(packages)
                             }
                         }
                     }
@@ -217,6 +219,12 @@ object Hermit {
         private fun updateHandlers(hermitPackage: HermitPackage) {
             HANDLER_EP_NAME.extensions.forEach {
                 it.handle(hermitPackage, project)
+            }
+        }
+
+        private fun reconcileHandlers(packages: List<HermitPackage>) {
+            HANDLER_EP_NAME.extensions.forEach {
+                it.reconcile(packages, project)
             }
         }
     }

--- a/src/main/kotlin/com/squareup/cash/hermit/HermitPropertyHandler.kt
+++ b/src/main/kotlin/com/squareup/cash/hermit/HermitPropertyHandler.kt
@@ -4,4 +4,11 @@ import com.intellij.openapi.project.Project
 
 interface HermitPropertyHandler {
     fun handle(hermitPackage: HermitPackage, project: Project)
+
+    /**
+     * Called once per update with the full set of packages, after every package has been handled.
+     * Handlers can use this to reconcile configuration that should be removed when hermit no longer
+     * manages a given package type (e.g. reverting a stale Gradle config). Defaults to a no-op.
+     */
+    fun reconcile(packages: List<HermitPackage>, project: Project) {}
 }

--- a/src/main/kotlin/com/squareup/cash/hermit/PropertyID.kt
+++ b/src/main/kotlin/com/squareup/cash/hermit/PropertyID.kt
@@ -2,4 +2,6 @@ package com.squareup.cash.hermit
 
 object PropertyID {
     val HermitEnabled = "hermit_enabled"
+    // The Gradle home the plugin configured as a local distribution, so it can be reverted later.
+    val HermitGradleHome = "hermit_gradle_home"
 }

--- a/src/main/kotlin/com/squareup/cash/hermit/gradle/GradleConfigUpdater.kt
+++ b/src/main/kotlin/com/squareup/cash/hermit/gradle/GradleConfigUpdater.kt
@@ -1,5 +1,6 @@
 package com.squareup.cash.hermit.gradle
 
+import com.intellij.ide.util.PropertiesComponent
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.externalSystem.service.execution.ExternalSystemJdkUtil
@@ -7,15 +8,18 @@ import com.intellij.openapi.project.Project
 import com.squareup.cash.hermit.HermitPackage
 import com.squareup.cash.hermit.HermitPropertyHandler
 import com.squareup.cash.hermit.PackageType
+import com.squareup.cash.hermit.PropertyID
 import com.squareup.cash.hermit.UI
 import org.jetbrains.plugins.gradle.settings.DistributionType
 import org.jetbrains.plugins.gradle.settings.GradleProjectSettings
+import java.io.File
+import java.nio.file.Path
 
 class GradleConfigUpdater : HermitPropertyHandler {
     private val log: Logger = Logger.getInstance(this.javaClass)
 
-    private fun notifyGradleUpdate(project: Project, name: String) {
-        UI.showInfo(project, "Hermit", "Switching to Gradle ${name}")
+    private fun notifyGradleUpdate(project: Project, message: String) {
+        UI.showInfo(project, "Hermit", message)
     }
 
     override fun handle(hermitPackage: HermitPackage, project: Project) {
@@ -28,12 +32,14 @@ class GradleConfigUpdater : HermitPropertyHandler {
                     newSettings.gradleHome = hermitPackage.path
                     newSettings.distributionType = DistributionType.LOCAL
                     GradleUtils.insertNewProjectSettings(project, newSettings)
-                    notifyGradleUpdate(project, hermitPackage.displayName())
+                    rememberHermitGradleHome(project, hermitPackage.path)
+                    notifyGradleUpdate(project, "Switching to Gradle ${hermitPackage.displayName()}")
                 } else if (!isUpToDate(settings, hermitPackage)) {
                     log.debug("updating project (" + project.name + ")  gradle config to " + hermitPackage.logString())
                     settings.gradleHome = hermitPackage.path
                     settings.distributionType = DistributionType.LOCAL
-                    notifyGradleUpdate(project, hermitPackage.displayName())
+                    rememberHermitGradleHome(project, hermitPackage.path)
+                    notifyGradleUpdate(project, "Switching to Gradle ${hermitPackage.displayName()}")
                 }
             }
         } else if (hermitPackage.type == PackageType.JDK) {
@@ -54,7 +60,81 @@ class GradleConfigUpdater : HermitPropertyHandler {
         }
     }
 
+    /**
+     * When hermit no longer manages a Gradle package, the local Gradle distribution the plugin
+     * previously configured is left behind. The IDE then tries to build with that stale installation
+     * instead of the project's Gradle wrapper, which fails when it points at a removed or wrong
+     * version. Revert back to the Gradle wrapper, but only if the configured local distribution was
+     * one the plugin set up from hermit, so we never touch a local install the user chose.
+     */
+    override fun reconcile(packages: List<HermitPackage>, project: Project) {
+        if (packages.any { it.type == PackageType.Gradle }) return
+
+        val settings = GradleUtils.findGradleProjectSettings(project) ?: return
+        if (settings.distributionType != DistributionType.LOCAL) return
+
+        val home = settings.gradleHome
+        if (!isFromHermit(project, home)) return
+
+        ApplicationManager.getApplication()?.runWriteAction {
+            log.debug("reverting project (" + project.name + ") gradle config from stale hermit local home '" + home + "' to the wrapper")
+            settings.gradleHome = null
+            settings.distributionType = DistributionType.DEFAULT_WRAPPED
+            forgetHermitGradleHome(project)
+        }
+        notifyGradleUpdate(project, "Reverting to the Gradle wrapper")
+    }
+
     private fun isUpToDate(settings: GradleProjectSettings, pkg: HermitPackage): Boolean {
         return settings.gradleHome == pkg.path && settings.distributionType == DistributionType.LOCAL
+    }
+
+    /**
+     * Whether the configured local Gradle home came from hermit. True if it matches the home the
+     * plugin recorded when it last configured Gradle (newer configs), or if it lives under a hermit
+     * state directory (older configs the plugin set up before it recorded the path).
+     *
+     * Hermit extracts packages to `<hermit-state>/pkg/<selector>`, where `<hermit-state>` is
+     * `$HERMIT_STATE_DIR` or the OS user cache dir + `/hermit`. See cashapp/hermit env.go.
+     */
+    private fun isFromHermit(project: Project, home: String?): Boolean {
+        if (home.isNullOrBlank()) return false
+        val recorded = PropertiesComponent.getInstance(project).getValue(PropertyID.HermitGradleHome)
+        if (home == recorded) return true
+
+        val homePath = try {
+            File(home).toPath().normalize()
+        } catch (_: Exception) {
+            return false
+        }
+        return hermitStateDirs().any { stateDir ->
+            try {
+                homePath.startsWith(stateDir.normalize())
+            } catch (_: Exception) {
+                false
+            }
+        }
+    }
+
+    private fun hermitStateDirs(): List<Path> {
+        val dirs = mutableListOf<Path>()
+        System.getenv("HERMIT_STATE_DIR")?.takeIf { it.isNotBlank() }?.let { dirs.add(Path.of(it)) }
+        val userHome = System.getProperty("user.home")
+        if (!userHome.isNullOrBlank()) {
+            // Linux / XDG default user cache dir
+            val xdgCache = System.getenv("XDG_CACHE_HOME")?.takeIf { it.isNotBlank() } ?: "$userHome/.cache"
+            dirs.add(Path.of(xdgCache, "hermit"))
+            // macOS default user cache dir
+            dirs.add(Path.of(userHome, "Library", "Caches", "hermit"))
+        }
+        return dirs
+    }
+
+    private fun rememberHermitGradleHome(project: Project, home: String) {
+        PropertiesComponent.getInstance(project).setValue(PropertyID.HermitGradleHome, home)
+    }
+
+    private fun forgetHermitGradleHome(project: Project) {
+        PropertiesComponent.getInstance(project).unsetValue(PropertyID.HermitGradleHome)
     }
 }

--- a/src/test/kotlin/com/squareup/cash/hermit/PluginIntegrationTest.kt
+++ b/src/test/kotlin/com/squareup/cash/hermit/PluginIntegrationTest.kt
@@ -11,6 +11,7 @@ import com.squareup.cash.hermit.gradle.GradleUtils
 import com.squareup.cash.hermit.ui.statusbar.HermitStatusBarPresentation
 import com.squareup.cash.hermit.ui.statusbar.HermitStatusBarWidget
 import junit.framework.TestCase
+import org.jetbrains.plugins.gradle.settings.DistributionType
 import org.junit.Test
 
 class PluginIntegrationTest : HermitProjectTestCase() {
@@ -93,6 +94,23 @@ class PluginIntegrationTest : HermitProjectTestCase() {
         waitAppThreads()
 
         TestCase.assertEquals("/root", GradleUtils.findGradleProjectSettings(project)?.gradleHome)
+    }
+
+    @Test fun `test it reverts a stale local Gradle config to the wrapper when hermit no longer manages Gradle`() {
+        withHermit(FakeHermit(listOf(TestPackage("gradle", "1.0", "", "/root", emptyMap()))))
+        Hermit(project).enable()
+        waitAppThreads()
+
+        TestCase.assertEquals("/root", GradleUtils.findGradleProjectSettings(project)?.gradleHome)
+        TestCase.assertEquals(DistributionType.LOCAL, GradleUtils.findGradleProjectSettings(project)?.distributionType)
+
+        // Gradle is no longer managed by hermit
+        withHermit(FakeHermit(listOf(TestPackage("name", "version", "", "root", mapOf(Pair("FOO", "BAR"))))))
+        Hermit(project).enable()
+        waitAppThreads()
+
+        TestCase.assertEquals(DistributionType.DEFAULT_WRAPPED, GradleUtils.findGradleProjectSettings(project)?.distributionType)
+        TestCase.assertNull(GradleUtils.findGradleProjectSettings(project)?.gradleHome)
     }
 
     @Test fun `test it sets the Gradle JDK home correctly, if both JDK and Gradle are present`() {


### PR DESCRIPTION
When hermit stops managing a Gradle package, the local Gradle distribution the plugin configured was left behind, so the IDE kept using a removed or wrong-version local install instead of the wrapper. Detect that case and revert to the Gradle wrapper, but only when the local home came from hermit.